### PR TITLE
chore: update tooling for Filament 4 and Laravel 11+

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -14,16 +14,15 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest]
         php: [8.2,8.3]
-        laravel: [10.*,11.*]
+        laravel: [11.*,12.*]
         stability: [ prefer-stable]
         include:
-          - laravel: 10.*
-            testbench: 8.*
-            filament: 3.*
-            carbon: 2.*
           - laravel: 11.*
             testbench: 9.*
-            filament: 3.*
+            filament: 4.*
+          - laravel: 12.*
+            testbench: 10.*
+            filament: 4.*
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 

--- a/composer.json
+++ b/composer.json
@@ -21,13 +21,14 @@
     ],
     "require": {
         "php": "^8.2",
-        "filament/filament": "^3.0",
+        "filament/filament": "^4.0",
         "laragear/two-factor": "^2.0",
-        "spatie/laravel-package-tools": "^1.15.0"
+        "spatie/laravel-package-tools": "^1.15.0",
+        "illuminate/support": "^11.0|^12.0"
     },
     "require-dev": {
         "nunomaduro/collision": "^7.9|^8.1",
-        "orchestra/testbench": "^8.0|9.0",
+        "orchestra/testbench": "^9.0|^10.0",
         "pestphp/pest": "^2.1",
         "pestphp/pest-plugin-arch": "^2.0",
         "pestphp/pest-plugin-laravel": "^2.0",

--- a/tests/UserPanelProvider.php
+++ b/tests/UserPanelProvider.php
@@ -3,7 +3,6 @@
 namespace Visualbuilder\Filament2fa\Tests;
 
 use Filament\Http\Middleware\Authenticate;
-use Filament\Http\Middleware\DisableBladeIconComponents;
 use Filament\Http\Middleware\DispatchServingFilamentEvent;
 use Filament\Navigation\MenuItem;
 use Filament\Panel;
@@ -51,7 +50,6 @@ class UserPanelProvider extends PanelProvider
                 ShareErrorsFromSession::class,
                 VerifyCsrfToken::class,
                 SubstituteBindings::class,
-                DisableBladeIconComponents::class,
                 DispatchServingFilamentEvent::class,
             ])
             ->authMiddleware([


### PR DESCRIPTION
## Summary
- support Filament 4 and Laravel 11/12 in composer
- test against PHP 8.2/8.3 with Laravel 11/12 and Filament 4 in CI
- drop obsolete Blade icon middleware from test panel provider

## Testing
- `composer update --prefer-dist --no-interaction` *(fails: CONNECT tunnel failed, response 403)*
- `composer test` *(fails: vendor/bin/pest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a47900931c8333b3c5bae1f7d23622