### PR TITLE
Fix dependency resolution for 2FA code verification

### DIFF
--- a/src/FilamentTwoFactor.php
+++ b/src/FilamentTwoFactor.php
@@ -46,7 +46,7 @@ class FilamentTwoFactor extends TwoFactor
      */
     protected function requestHasCode(): bool
     {
-        return ! validator(['totp_code' => $this->code], ['totp_code' => 'required|alpha_num'])->fails();
+        return ! validator(['totp_code' => $this->input], ['totp_code' => 'required|alpha_num'])->fails();
     }
 
     /**
@@ -54,7 +54,7 @@ class FilamentTwoFactor extends TwoFactor
      */
     protected function getCode(): string
     {
-        return $this->code;
+        return $this->input;
     }
 
     /**

--- a/src/Livewire/Confirm2Fa.php
+++ b/src/Livewire/Confirm2Fa.php
@@ -85,7 +85,7 @@ class Confirm2Fa extends SimplePage
         } else {
             if (app(FilamentTwoFactor::class,
                 [
-                    'code'            => $formData['totp_code'],
+                    'input'           => $formData['totp_code'],
                     'safeDeviceInput' => isset($formData['safe_device_enable']) ? $formData['safe_device_enable'] : false
                 ])->validate2Fa($user)) {
                 $sessionKey = config('filament-2fa.login.credential_key', '_2fa_login');


### PR DESCRIPTION
## Summary
- Pass OTP value using the `input` parameter when resolving `FilamentTwoFactor`
- Use inherited `$input` property instead of `$code` in `FilamentTwoFactor`

## Testing
- `composer install --no-progress --no-interaction` *(fails: CONNECT tunnel failed, response 403)*
- `composer test` *(fails: vendor/bin/pest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a6628255288333873061e30a22be8e