### PR TITLE
Fix dependency resolution for 2FA code verification

### DIFF
--- a/src/FilamentTwoFactor.php
+++ b/src/FilamentTwoFactor.php
@@ -2,66 +2,9 @@
 
 namespace Visualbuilder\Filament2fa;
 
-use Closure;
-use Illuminate\Auth\Events\Authenticated;
-use Illuminate\Contracts\Auth\Authenticatable;
-use Illuminate\Contracts\Config\Repository;
-use Illuminate\Http\Request;
-use Laragear\TwoFactor\Contracts\TwoFactorAuthenticatable;
-use Laragear\TwoFactor\Exceptions\InvalidCodeException;
 use Laragear\TwoFactor\TwoFactor;
-
-use function validator;
 
 class FilamentTwoFactor extends TwoFactor
 {
-//    /**
-//     * Creates a new Laraguard instance.
-//     */
-//    public function __construct(
-//        protected Repository $config,
-//        protected Request $request,
-//        protected string $input,
-//        protected string $safeDeviceInput,
-//    ) {
-//
-//    }
-
-
-    public function validate2Fa(Authenticatable $user)
-    {
-        // If the code is valid, return true only after we try to save the safe device.
-        if ($this->requestHasCode() && $user->validateTwoFactorCode($this->getCode())) {
-            if ($this->isSafeDevicesEnabled() && $this->wantsToAddDevice()) {
-                $user->addSafeDevice($this->request);
-            }
-
-            return true;
-        }
-    }
-
-
-    /**
-     * Checks if the Request has a Two-Factor Code and is valid.
-     */
-    protected function requestHasCode(): bool
-    {
-        return ! validator(['totp_code' => $this->code], ['totp_code' => 'required|alpha_num'])->fails();
-    }
-
-    /**
-     * Returns the code from the request input.
-     */
-    protected function getCode(): string
-    {
-        return $this->code;
-    }
-
-    /**
-     * Checks if the user wants to add this device as "safe".
-     */
-    protected function wantsToAddDevice(): bool
-    {
-        return (bool)$this->safeDeviceInput;
-    }
+    // Intentionally extend base TwoFactor without modifications.
 }

--- a/src/Livewire/Confirm2Fa.php
+++ b/src/Livewire/Confirm2Fa.php
@@ -76,38 +76,44 @@ class Confirm2Fa extends SimplePage
 
     public function submit(): void
     {
-        $formData = $this->form->getState();
+        // Trigger form validation and retrieve state.
+        $this->form->getState();
 
         $user = $this->authenticate();
 
-        if (!$user) {
+        if (! $user) {
             $this->redirect(Filament::getUrl());
-        } else {
-            if (app(FilamentTwoFactor::class,
-                [
-                    'code'            => $formData['totp_code'],
-                    'safeDeviceInput' => isset($formData['safe_device_enable']) ? $formData['safe_device_enable'] : false
-                ])->validate2Fa($user)) {
-                $sessionKey = config('filament-2fa.login.credential_key', '_2fa_login');
 
-                Notification::make()
-                    ->title('Success')
-                    ->body(__('filament-2fa::two-factor.success'))
-                    ->icon('heroicon-o-check-circle')
-                    ->color('success')
-                    ->send();
-
-                session()->forget("{$sessionKey}.credentials");
-                session()->forget("{$sessionKey}.remember");
-                session()->forget("{$sessionKey}.panel_id");
-
-                $this->redirectIntended(Filament::getUrl());
-            } else {
-                Filament::auth()->logout();
-                session()->regenerate();
-                $this->throwTotpcodeValidationException();
-            }
+            return;
         }
+
+        $twoFactorValid = app(FilamentTwoFactor::class, [
+            'input' => 'totp_code',
+            'safeDeviceInput' => 'safe_device_enable',
+        ])->validate($user);
+
+        if ($twoFactorValid) {
+            $sessionKey = config('filament-2fa.login.credential_key', '_2fa_login');
+
+            Notification::make()
+                ->title('Success')
+                ->body(__('filament-2fa::two-factor.success'))
+                ->icon('heroicon-o-check-circle')
+                ->color('success')
+                ->send();
+
+            session()->forget("{$sessionKey}.credentials");
+            session()->forget("{$sessionKey}.remember");
+            session()->forget("{$sessionKey}.panel_id");
+
+            $this->redirectIntended(Filament::getUrl());
+
+            return;
+        }
+
+        Filament::auth()->logout();
+        session()->regenerate();
+        $this->throwTotpcodeValidationException();
     }
 
     public function authenticate(): null|bool|Model


### PR DESCRIPTION
## Summary
- Simplify `FilamentTwoFactor` to rely on base `TwoFactor` implementation
- Validate 2FA using request field names in `Confirm2Fa` and call base `validate`

## Testing
- `composer install --no-progress --no-interaction` *(fails: CONNECT tunnel failed, response 403)*
- `composer test` *(fails: vendor/bin/pest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a6628255288333873061e30a22be8e