### PR TITLE
Fix undefined form data usage in Confirm2Fa

### DIFF
--- a/src/Livewire/Confirm2Fa.php
+++ b/src/Livewire/Confirm2Fa.php
@@ -77,42 +77,19 @@ class Confirm2Fa extends SimplePage
     public function submit(): void
     {
         // Trigger form validation and retrieve state.
-        $this->form->getState();
+        $formData = $this->form->getState();
 
         $user = $this->authenticate();
 
         if (! $user) {
             $this->redirect(Filament::getUrl());
-        } else {
-            if (app(FilamentTwoFactor::class,
-                [
-                    'input'           => $formData['totp_code'],
-                    'safeDeviceInput' => isset($formData['safe_device_enable']) ? $formData['safe_device_enable'] : false
-                ])->validate2Fa($user)) {
-                $sessionKey = config('filament-2fa.login.credential_key', '_2fa_login');
 
-                Notification::make()
-                    ->title('Success')
-                    ->body(__('filament-2fa::two-factor.success'))
-                    ->icon('heroicon-o-check-circle')
-                    ->color('success')
-                    ->send();
-
-                session()->forget("{$sessionKey}.credentials");
-                session()->forget("{$sessionKey}.remember");
-                session()->forget("{$sessionKey}.panel_id");
-
-                $this->redirectIntended(Filament::getUrl());
-            } else {
-                Filament::auth()->logout();
-                session()->regenerate();
-                $this->throwTotpcodeValidationException();
-            }
+            return;
         }
 
         $twoFactorValid = app(FilamentTwoFactor::class, [
-            'input' => 'totp_code',
-            'safeDeviceInput' => 'safe_device_enable',
+            'input' => $formData['totp_code'] ?? null,
+            'safeDeviceInput' => $formData['safe_device_enable'] ?? false,
         ])->validate($user);
 
         if ($twoFactorValid) {


### PR DESCRIPTION
## Summary
- simplify 2FA submit handler to use retrieved form state
- validate codes directly using FilamentTwoFactor service

## Testing
- `composer install --no-interaction --prefer-dist` *(fails: CONNECT tunnel failed, response 403)*
- `vendor/bin/pest` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a66c60cee483339a71d1a4d964c395