### PR TITLE
Fix undefined form data usage in Confirm2Fa

### DIFF
--- a/src/Livewire/Confirm2Fa.php
+++ b/src/Livewire/Confirm2Fa.php
@@ -76,41 +76,19 @@ class Confirm2Fa extends SimplePage
 
     public function submit(): void
     {
-        // Trigger form validation and retrieve state.
-        $this->form->getState();
+        // Trigger form validation and ensure fields are present.
+        $this->form->validate();
 
         $user = $this->authenticate();
 
         if (! $user) {
             $this->redirect(Filament::getUrl());
-        } else {
-            if (app(FilamentTwoFactor::class,
-                [
-                    'input'           => $formData['totp_code'],
-                    'safeDeviceInput' => isset($formData['safe_device_enable']) ? $formData['safe_device_enable'] : false
-                ])->validate2Fa($user)) {
-                $sessionKey = config('filament-2fa.login.credential_key', '_2fa_login');
 
-                Notification::make()
-                    ->title('Success')
-                    ->body(__('filament-2fa::two-factor.success'))
-                    ->icon('heroicon-o-check-circle')
-                    ->color('success')
-                    ->send();
-
-                session()->forget("{$sessionKey}.credentials");
-                session()->forget("{$sessionKey}.remember");
-                session()->forget("{$sessionKey}.panel_id");
-
-                $this->redirectIntended(Filament::getUrl());
-            } else {
-                Filament::auth()->logout();
-                session()->regenerate();
-                $this->throwTotpcodeValidationException();
-            }
+            return;
         }
 
         $twoFactorValid = app(FilamentTwoFactor::class, [
+            // Use input field names so the TwoFactor service pulls values from the request.
             'input' => 'totp_code',
             'safeDeviceInput' => 'safe_device_enable',
         ])->validate($user);


### PR DESCRIPTION
## Summary
- validate form fields directly and remove unused form state
- pass field names to FilamentTwoFactor so codes are read from the request

## Testing
- `php -l src/Livewire/Confirm2Fa.php`
- `composer install --no-interaction --prefer-dist` *(fails: CONNECT tunnel failed, response 403)*
- `vendor/bin/pest` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a66c60cee483339a71d1a4d964c395