### PR TITLE
fix: ensure 2FA label exists

### DIFF
--- a/src/Filament/Pages/Configure.php
+++ b/src/Filament/Pages/Configure.php
@@ -102,6 +102,17 @@ class Configure extends SimplePage
             $record = $user->createTwoFactorAuth(); // create once
         }
 
+        // Some versions of the underlying library expect a "label" attribute
+        // on the TwoFactorAuth model to derive the issuer. When the label is
+        // missing calling `toQr()` or `toUri()` would throw an exception.
+        // Ensure the label is always present by defaulting to the application
+        // name and the user's email (or their identifier if email is missing).
+        if (! $record->label) {
+            $email = $user->email ?? $user->getAuthIdentifier();
+            $record->label = config('app.name') . ':' . $email;
+            $record->save();
+        }
+
         $this->provisioning = [
             'qr'     => $record->toQr(),
             'uri'    => $record->toUri(),


### PR DESCRIPTION
## Summary
- avoid undefined `label` when provisioning 2FA by auto-populating it with app name and user email

## Testing
- `composer test` *(fails: vendor/bin/pest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a70375296083338422f7da7298c985