### PR TITLE
Respect device remember toggle

### DIFF
--- a/src/Filament/Pages/Confirm2Fa.php
+++ b/src/Filament/Pages/Confirm2Fa.php
@@ -113,10 +113,15 @@ class Confirm2Fa extends SimplePage
             $code = (string) ($state['totp_code'] ?? '');
             $this->processingCode = $code;
 
-            request()->merge([
+            $requestData = [
                 'totp_code' => $code,
-                'safe_device_enable' => (bool) ($state['safe_device_enable'] ?? false),
-            ]);
+            ];
+
+            if ($state['safe_device_enable'] ?? false) {
+                $requestData['safe_device_enable'] = true;
+            }
+
+            request()->merge($requestData);
 
             $twoFactorValid = app(\Visualbuilder\Filament2fa\FilamentTwoFactor::class, [
                 'input' => 'totp_code',

--- a/tests/Unit/Confirm2FaTest.php
+++ b/tests/Unit/Confirm2FaTest.php
@@ -101,3 +101,56 @@ it('Confirm 2FA TOTP code', function () {
         ->call('submit');
     expect(auth()->user()->email)->toEqual('admin@domain.com');
 });
+
+it('does not remember the device when toggle is off', function () {
+    $user = $this->createUser();
+    $user->twoFactorAuth()->save(
+        TwoFactorAuthentication::factory()->make()
+    );
+    expect($user->hasTwoFactorEnabled())->toBeTrue();
+
+    livewire(Login::class)
+        ->assertFormExists()
+        ->fillForm([
+            'email' => 'admin@domain.com',
+            'password' => 'password'
+        ])
+        ->call('authenticate')
+        ->assertRedirect(config('filament-2fa.login.confirm_totp_page_url'));
+
+    livewire(Confirm2Fa::class)
+        ->fillForm([
+            'totp_code' => $user->makeTwoFactorCode(),
+        ])
+        ->call('submit');
+
+    $user->refresh();
+    expect($user->twoFactorAuth->safe_devices)->toBeEmpty();
+});
+
+it('remembers the device when toggle is on', function () {
+    $user = $this->createUser();
+    $user->twoFactorAuth()->save(
+        TwoFactorAuthentication::factory()->make()
+    );
+    expect($user->hasTwoFactorEnabled())->toBeTrue();
+
+    livewire(Login::class)
+        ->assertFormExists()
+        ->fillForm([
+            'email' => 'admin@domain.com',
+            'password' => 'password'
+        ])
+        ->call('authenticate')
+        ->assertRedirect(config('filament-2fa.login.confirm_totp_page_url'));
+
+    livewire(Confirm2Fa::class)
+        ->fillForm([
+            'totp_code' => $user->makeTwoFactorCode(),
+            'safe_device_enable' => true,
+        ])
+        ->call('submit');
+
+    $user->refresh();
+    expect($user->twoFactorAuth->safe_devices)->not()->toBeEmpty();
+});


### PR DESCRIPTION
## Summary
- ensure 2FA confirm page only remembers safe device when user opts in
- add tests covering safe device toggle behavior

## Testing
- `composer install` *(fails: CONNECT tunnel failed, response 403)*
- `composer test` *(fails: vendor/bin/pest: not found)*


------
https://chatgpt.com/codex/tasks/task_e_68b574d7b7688333b7f3d11cb78b1104